### PR TITLE
Update README to reflect tensorpack versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Python packages: numpy, scipy, tables, pymdptoolbox, tensorpack
 To install these packages using pip:
 ```
 pip install tensorflow
-pip install numpy scipy tables pymdptoolbox tensorpack
+pip install numpy scipy tables pymdptoolbox tensorpack==0.9.1
 ```
 
 Optional: to speed up data generation download and install the latest version of pymdptoolbox


### PR DESCRIPTION
Just a small README edit to address an issue with running the repo:

`import tensorpack` fails for Tensorpack 0.10 and greater with Python 2.7.

Attempting to import Tensorpack after installing from pip causes `AttributeError: 'module' object has no attribute 'lru_cache'`. This is likely because ver 0.10 and higher are only compatible with Python 3, as the `lru_cache` attribute did not exist in `functools` until Python 3.2. ([source](https://docs.python.org/3/library/functools.html#functools.lru_cache))
